### PR TITLE
feat(renderer):hash password to 256 bits as key

### DIFF
--- a/lumium-renderer/Cargo.toml
+++ b/lumium-renderer/Cargo.toml
@@ -45,6 +45,7 @@ features = [
     'RequestMode',
     'Response',
     'Window',
+    'File'
 ]
 
 [dev-dependencies]

--- a/lumium-renderer/Cargo.toml
+++ b/lumium-renderer/Cargo.toml
@@ -45,7 +45,6 @@ features = [
     'RequestMode',
     'Response',
     'Window',
-    'File'
 ]
 
 [dev-dependencies]

--- a/lumium-renderer/Cargo.toml
+++ b/lumium-renderer/Cargo.toml
@@ -49,11 +49,11 @@ features = [
 ]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.13"
+wasm-bindgen-test = "0.3.33"
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.
-opt-level = "s"
+#opt-level = "s"
 
 [build-dependencies]
 dotenv = "0.15.0"

--- a/lumium-renderer/js/download.js
+++ b/lumium-renderer/js/download.js
@@ -1,0 +1,12 @@
+export function download(filename, text) {
+    var element = document.createElement('a');
+    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+    element.setAttribute('download', filename);
+
+    element.style.display = 'none';
+    document.body.appendChild(element);
+
+    element.click();
+
+    document.body.removeChild(element);
+}

--- a/lumium-renderer/src/lib.rs
+++ b/lumium-renderer/src/lib.rs
@@ -23,6 +23,11 @@ use ring::rand::{SecureRandom, SystemRandom};
 use seed::{self, prelude::*, *};
 use serde::{Deserialize, Serialize};
 
+#[wasm_bindgen(module = "/js/download.js")]
+extern "C" {
+    fn download(file: String, content: String);
+}
+
 const MASTER_KEY_BYTE_LENGTH: usize = 32;
 const ACTIVATOR_KEY_BYTE_LENGTH: usize = 32;
 const RECOVERY_CODES_FILE_NAME: &str = "lumium_recovery_codes.txt";
@@ -215,10 +220,10 @@ pub async fn create_workspace(password: JsValue) -> Result<JsValue, JsValue> {
 
     let json = JsFuture::from(resp.json()?).await?;
 
-    let file = web_sys::File::new_with_buffer_source_sequence(
-        &JsValue::from(recovery_codes.join("\n")),
-        RECOVERY_CODES_FILE_NAME,
-    )?;
+    download(
+        RECOVERY_CODES_FILE_NAME.to_string(),
+        recovery_codes.join("\n"),
+    );
 
     Ok(json)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,7 +2514,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.9.0", "@types/react@^17", "@types/react@^17.0.0":
+"@types/react@*", "@types/react@17.0.15", "@types/react@>=16.9.0", "@types/react@^17", "@types/react@^17.0.0":
   version "17.0.15"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.15.tgz#c7533dc38025677e312606502df7656a6ea626d0"
   integrity sha512-uTKHDK9STXFHLaKv6IMnwp52fm0hwU+N89w/p9grdUqcFA6WuqDyPhaWopbNyE1k/VhgzmHl8pu1L4wITtmlLw==


### PR DESCRIPTION
the end to end encryption scheme now uses normalized key length of 256
bits. on the client this is ensured by simply taking the SHA256 of the
workspace password.
